### PR TITLE
Prevent override of logfiles

### DIFF
--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -9,6 +9,7 @@
 
 #include "Logfile.hpp"
 #include <fstream>
+#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 
 using namespace logger;
@@ -56,6 +57,12 @@ bool Logger::startHook()
 {
     if (_file.value().empty())
         return false;
+
+    if(boost::filesystem::exists(_file.value()))
+    {
+        log(Error) << "File " << _file.value() << " already exists." << endlog();
+        return false;
+    }
 
     // The registry has been loaded on construction
     // Now, create the output file


### PR DESCRIPTION
This is for discussion.

We had usecases that the logger has overriden logfiles, this commit prevents this but results in strange filenames. I would prefer creepy filenames instead overriding logfiles.

(the source of course has to be fixed also, but to be robust in the future i recommend this commit)
