### PR TITLE
Fix for clang and cxx11 compatibility

### DIFF
--- a/tasks/Logfile.hpp
+++ b/tasks/Logfile.hpp
@@ -79,8 +79,7 @@ namespace Logging
 
     namespace details
     {
-        template <bool value> struct static_check;
-        template<> struct static_check<true> {};
+        template <typename T> struct static_failure;
     }
 
     /** Writes the file prologue */
@@ -89,7 +88,7 @@ namespace Logging
     template<class T>
     Logfile& operator << (Logfile& output, const T& value)
     {
-        details::static_check<false> test;
+        details::static_failure<T> IF_YOU_HAVE_AN_ERROR_HERE_YOU_USED_THE_STREAM_OPERATOR_WITH_AN_INVALID_TYPE;
         return output;
     }
 


### PR DESCRIPTION
This is simliar to:
https://github.com/rock-core/tools-pocolog_cpp/pull/4

This function causes clang with cxx11 features to build failures
It seems that this compiler setup evaluates the funtion at compiletime
of this lib. Nevertheless the whole function is not needed because
it postprones the error to here. Otherwise the user would get a warning
that his required specialization of the streaming is not implemented.