### PR TITLE
Auto timestamp existing log files instead of overwriting

### DIFF
--- a/logger.orogen
+++ b/logger.orogen
@@ -48,7 +48,7 @@ task_context "Logger" do
     # configure. The default is to fail, but this flag is needed if one wants to
     # use safe temporary files as targets
     property 'overwrite_existing_files', '/bool', false
-    property 'auto_rename_existing_files', '/bool', false
+    property 'auto_timestamp_files', '/bool', false
     attribute 'current_file', 'std/string'
 end
 

--- a/logger.orogen
+++ b/logger.orogen
@@ -49,6 +49,7 @@ task_context "Logger" do
     # use safe temporary files as targets
     property 'overwrite_existing_files', '/bool', false
     property 'auto_rename_existing_files', '/bool', false
+    attribute 'current_file', 'std/string'
 end
 
 typekit do

--- a/logger.orogen
+++ b/logger.orogen
@@ -45,7 +45,7 @@ task_context "Logger" do
         doc "the output file name"
 
     # Controls whether the logger should overwrite or timestamp an existing file, if it already exists.
-    # The default is to fail, but one of this flags is needed, if one wants to use safe temporary files as targets.
+    # The default is to fail, but one of these flags is needed, if one wants to use safe temporary files as targets.
     # The flags are mutually exclusive, therefore the task will fail if both are true.
     property 'overwrite_existing_files', '/bool', false
     property 'auto_timestamp_files'    , '/bool', false

--- a/logger.orogen
+++ b/logger.orogen
@@ -44,11 +44,11 @@ task_context "Logger" do
     property("file", "std/string").
         doc "the output file name"
 
-    # Controls whether the logger should overwrite an existing file or fail in
-    # configure. The default is to fail, but this flag is needed if one wants to
-    # use safe temporary files as targets
+    # Controls whether the logger should overwrite or timestamp an existing file, if it already exists.
+    # The default is to fail, but one of this flags is needed, if one wants to use safe temporary files as targets.
+    # The flags are mutually exclusive, therefore the task will fail if both are true.
     property 'overwrite_existing_files', '/bool', false
-    property 'auto_timestamp_files', '/bool', false
+    property 'auto_timestamp_files'    , '/bool', false
     attribute 'current_file', 'std/string'
 end
 

--- a/logger.orogen
+++ b/logger.orogen
@@ -48,6 +48,7 @@ task_context "Logger" do
     # configure. The default is to fail, but this flag is needed if one wants to
     # use safe temporary files as targets
     property 'overwrite_existing_files', '/bool', false
+    property 'auto_rename_existing_files', '/bool', false
 end
 
 typekit do

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -69,19 +69,18 @@ bool Logger::startHook()
 
     _current_file.set(_file.value());
 
-    if(_overwrite_existing_files.get() && _auto_rename_existing_files.get())
+    if(boost::filesystem::exists(_current_file.get()) && !_overwrite_existing_files.get() && !_auto_timestamp_files.get())
     {
-      log(Error) << "Ambiguous property values. Both _overwrite_existing_files and _auto_rename_existing_files are set to true." << endlog();
+      log(Error) << "File " << _current_file.get() << " already exists. Neither overwrite nor auto-timestamp allowed by task properties." << endlog();
       return false;
     }
 
-    if(boost::filesystem::exists(_current_file.get()) && !_overwrite_existing_files.get() && !_auto_rename_existing_files.get())
+    if(boost::filesystem::exists(_current_file.get()) && _overwrite_existing_files.get() && !_auto_timestamp_files.get())
     {
-      log(Error) << "File " << _current_file.get() << " already exists. No overwrite allowed by task property." << endlog();
-      return false;
+      log(Info) << "File " << _current_file.get() << " already exists. Overwriting existing file." << endlog();
     }
 
-    if(boost::filesystem::exists(_current_file.get()) && !_overwrite_existing_files.get() && _auto_rename_existing_files.get())
+    if(boost::filesystem::exists(_current_file.get()) && _auto_timestamp_files.get())
     {
         log(Warning) << "File " << _current_file.get() << " already exists." << endlog();
         renameFile();

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -407,7 +407,7 @@ bool Logger::handleExistingFile()
             usleep(1*1000000);
             renameFile();
         }
-        log(Info) << "Writing to " << _current_file.get() << " ." << endlog();
+        log(Warning) << "Writing log to " << _current_file.get() << " instead." << endlog();
         return true;
     }
 }

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -73,6 +73,12 @@ bool Logger::startHook()
       return false;
     }
 
+    if(boost::filesystem::exists(_file.value()) && !_overwrite_existing_files.get() && !_auto_rename_existing_files.get())
+    {
+      log(Error) << "File " << _file.value() << " already exists. No overwrite allowed by task property." << endlog();
+      return false;
+    }
+
     if(boost::filesystem::exists(_file.value()) && !_overwrite_existing_files.get() && _auto_rename_existing_files.get())
     {
         log(Warning) << "File " << _file.value() << " already exists." << endlog();
@@ -92,7 +98,7 @@ bool Logger::startHook()
           return false;
         }
         _file.set(timestamped_str);
-        log(Warning) << "Writing to " << _file.value() << " ." << endlog();
+        log(Info) << "Writing to " << _file.value() << " ." << endlog();
     }
 
     // The registry has been loaded on construction

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -382,7 +382,8 @@ void Logger::timestampFile()
     // append suffix to previous _file.value()
     vector<string> strs;
     boost::split(strs, _file.value(), boost::is_any_of("."));
-    if ( strs.size() == 1) {
+    if ( strs.size() == 1)
+    {
         strs.insert(strs.end(), std::string(suffix));
     } else {
         strs.insert(strs.end()-1, std::string(suffix));

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -67,7 +67,13 @@ bool Logger::startHook()
       return false;
     }
 
-    if(boost::filesystem::exists(_file.value()) && !_overwrite_existing_files.get())
+    if(_overwrite_existing_files.get() && _auto_rename_existing_files.get())
+    {
+      log(Error) << "Ambiguous property values. Both _overwrite_existing_files and _auto_rename_existing_files are set to true." << endlog();
+      return false;
+    }
+
+    if(boost::filesystem::exists(_file.value()) && !_overwrite_existing_files.get() && _auto_rename_existing_files.get())
     {
         log(Warning) << "File " << _file.value() << " already exists." << endlog();
         // create timestamp
@@ -80,11 +86,12 @@ bool Logger::startHook()
         boost::split(strs, _file.value(), boost::is_any_of("."));
         strs.insert(strs.end()-1, std::string(suffix));
         // safety check if timestamped file exists
-        if(boost::filesystem::exists(boost::algorithm::join(strs, "."))) {
-          log(Error) << "Timestamped file " << _file.value() << " already exists." << endlog();
+        std::string timestamped_str = boost::algorithm::join(strs, ".");
+        if(boost::filesystem::exists(timestamped_str)) {
+          log(Error) << "Timestamped file " << _file.value() << " already exists. Please retry." << endlog();
           return false;
         }
-        _file.set(boost::algorithm::join(strs, "."));
+        _file.set(timestamped_str);
         log(Warning) << "Writing to " << _file.value() << " ." << endlog();
     }
 

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -377,8 +377,11 @@ void Logger::renameFile()
     // append suffix to previous _current_file.get()
     vector<string> strs;
     boost::split(strs, _file.value(), boost::is_any_of("."));
-    strs.insert(strs.end()-1, std::string(suffix));
-    // safety check if timestamped file exists
+    if ( strs.size() == 1) {
+        strs.insert(strs.end(), std::string(suffix));
+    } else {
+        strs.insert(strs.end()-1, std::string(suffix));
+    }
     std::string timestamped_str = boost::algorithm::join(strs, ".");
     _current_file.set(timestamped_str);
 }

--- a/tasks/Logger.hpp
+++ b/tasks/Logger.hpp
@@ -76,6 +76,10 @@ namespace logger {
 
         bool removeLoggingPort(std::string const& stream_name);
 
+        /** Timestamp output file for automatic renaming capability
+         *  Sets _current_file attribute */
+        void renameFile();
+
     private:
         typedef RTT::DataFlowInterface::Ports Ports;
 

--- a/tasks/Logger.hpp
+++ b/tasks/Logger.hpp
@@ -78,7 +78,7 @@ namespace logger {
 
         /** Timestamp output file for automatic renaming capability
          *  Sets _current_file attribute */
-        void renameFile();
+        void timestampFile();
         
         /** Handle file naming/overwriting if output file already exists */
         bool handleExistingFile();

--- a/tasks/Logger.hpp
+++ b/tasks/Logger.hpp
@@ -79,6 +79,9 @@ namespace logger {
         /** Timestamp output file for automatic renaming capability
          *  Sets _current_file attribute */
         void renameFile();
+        
+        /** Handle file naming/overwriting if output file already exists */
+        bool handleExistingFile();
 
     private:
         typedef RTT::DataFlowInterface::Ports Ports;

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -113,6 +113,17 @@ class TC_BasicBehaviour < Minitest::Test
         assert(task.file != task.current_file)
     end
 
+    def test_no_suffix_log_file
+        task.overwrite_existing_files = false
+        task.auto_timestamp_files = true
+        task.file = "/tmp/rock_logger_test"
+        touch_file = File.new(task.file, "w")
+        assert(!task.has_port?('time'))
+        assert(task.createLoggingPort('time', '/base/Time', []))
+        generate_and_check_logfile
+        assert(task.file != task.current_file)
+    end
+
     def test_metadata
         assert(!task.has_port?('time'))
         meta = []

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -92,6 +92,19 @@ class TC_BasicBehaviour < Minitest::Test
         generate_and_check_logfile
     end
 
+    def test_re_renaming
+        task.overwrite_existing_files = false
+        task.auto_rename_existing_files = true
+        touch_file = File.new(task.file, "w")
+        assert(!task.has_port?('time'))
+        assert(task.createLoggingPort('time', '/base/Time', []))
+        task.configure
+        task.start
+        task.stop
+        task.start
+        assert(task.file != task.current_file)
+    end
+
     def test_ambiguous_properties
         task.overwrite_existing_files = true
         task.auto_rename_existing_files = true

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -75,7 +75,7 @@ class TC_BasicBehaviour < Minitest::Test
         meta << Hash['key' => 'key1', 'value' => 'value1']
         assert(task.createLoggingPort('time', '/base/Time', meta))
         stream = generate_and_check_logfile
-        assert_equal({'key0' => 'value0', 'key1' => 'value1'}, stream.metadata)
+        assert_equal({'key0' => 'value0', 'key1' => 'value1', 'rock_cxx_type_name' => '/base/Time'}, stream.metadata)
     end
 
     def test_create_port_log
@@ -93,7 +93,8 @@ class TC_BasicBehaviour < Minitest::Test
             'rock_task_model' => nil,
             'rock_task_name' => 'source',
             'rock_task_object_name' => 'out',
-            'rock_orocos_type_name' => '/int32_t'
+            'rock_orocos_type_name' => '/int32_t',
+            'rock_cxx_type_name' => '/int32_t'
         }
         assert_equal expected_metadata, stream.metadata
     end
@@ -131,7 +132,8 @@ class TC_BasicBehaviour < Minitest::Test
             'rock_task_model' => nil,
             'rock_task_name' => 'source',
             'rock_task_object_name' => 'file',
-            'rock_orocos_type_name' => '/std/string'
+            'rock_orocos_type_name' => '/std/string',
+            'rock_cxx_type_name' => '/std/string'
         }
         assert_equal expected_metadata, stream.metadata
     end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -3,7 +3,6 @@ require 'orocos/test/component'
 
 require 'pocolog'
 require 'fileutils'
-require 'pry'
 
 class TC_BasicBehaviour < Minitest::Test
     include Orocos::Test::Component
@@ -90,6 +89,7 @@ class TC_BasicBehaviour < Minitest::Test
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile
+        assert(task.file != task.current_file)
     end
 
     def test_re_renaming
@@ -101,7 +101,7 @@ class TC_BasicBehaviour < Minitest::Test
         task.configure
         task.start
         task.stop
-        task.start
+        generate_and_check_logfile
         assert(task.file != task.current_file)
     end
 

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -93,7 +93,6 @@ class TC_BasicBehaviour < Minitest::Test
     def test_auto_timestamp_file
         task.overwrite_existing_files = false
         task.auto_timestamp_files = true
-        touch_file = File.new(task.file, "w")
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile
@@ -103,7 +102,6 @@ class TC_BasicBehaviour < Minitest::Test
     def test_re_stamping_existing_timestamped_file
         task.overwrite_existing_files = false
         task.auto_timestamp_files = true
-        touch_file = File.new(task.file, "w")
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         task.configure
@@ -117,7 +115,6 @@ class TC_BasicBehaviour < Minitest::Test
         task.overwrite_existing_files = false
         task.auto_timestamp_files = true
         task.file = "/tmp/rock_logger_test"
-        touch_file = File.new(task.file, "w")
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -14,8 +14,8 @@ class TC_BasicBehaviour < Minitest::Test
 
     def setup
         super
-        task.overwrite_existing_files = false
-        task.auto_rename_existing_files = true
+        task.overwrite_existing_files = true
+        task.auto_rename_existing_files = false
         task.file = logfile_path
     end
 
@@ -78,6 +78,34 @@ class TC_BasicBehaviour < Minitest::Test
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile
+    end
+
+    def test_no_overwrite
+        task.overwrite_existing_files = false
+        task.auto_rename_existing_files = false
+        task.configure
+        assert_raises Orocos::StateTransitionFailed do
+          task.start
+        end
+        puts '[INFO] This Error is expected and handled.'
+    end
+
+    def test_auto_renaming
+        task.overwrite_existing_files = false
+        task.auto_rename_existing_files = true
+        assert(!task.has_port?('time'))
+        assert(task.createLoggingPort('time', '/base/Time', []))
+        generate_and_check_logfile
+    end
+
+    def test_ambiguous_properties
+        task.overwrite_existing_files = true
+        task.auto_rename_existing_files = true
+        task.configure
+        assert_raises Orocos::StateTransitionFailed do
+          task.start
+        end
+        puts '[INFO] This Error is expected and handled.'
     end
 
     def test_metadata

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -15,7 +15,7 @@ class TC_BasicBehaviour < Minitest::Test
     def setup
         super
         task.overwrite_existing_files = true
-        task.auto_rename_existing_files = false
+        task.auto_timestamp_files = false
         task.file = "/tmp/rock_logger_test.log"
     end
 
@@ -71,20 +71,19 @@ class TC_BasicBehaviour < Minitest::Test
         generate_and_check_logfile
     end
 
-    def test_no_overwrite
+    def test_no_overwrite_expect_transition_error
         task.overwrite_existing_files = false
-        task.auto_rename_existing_files = false
+        task.auto_timestamp_files = false
         task.configure
         touch_file = File.new(task.file, "w")
         assert_raises Orocos::StateTransitionFailed do
             task.start
         end
-        puts '[INFO] This Error is expected and handled.'
     end
 
-    def test_auto_renaming
+    def test_auto_timestamp_file
         task.overwrite_existing_files = false
-        task.auto_rename_existing_files = true
+        task.auto_timestamp_files = true
         touch_file = File.new(task.file, "w")
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
@@ -92,9 +91,9 @@ class TC_BasicBehaviour < Minitest::Test
         assert(task.file != task.current_file)
     end
 
-    def test_re_renaming
+    def test_re_stamping_existing_timestamped_file
         task.overwrite_existing_files = false
-        task.auto_rename_existing_files = true
+        task.auto_timestamp_files = true
         touch_file = File.new(task.file, "w")
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
@@ -103,16 +102,6 @@ class TC_BasicBehaviour < Minitest::Test
         task.stop
         generate_and_check_logfile
         assert(task.file != task.current_file)
-    end
-
-    def test_ambiguous_properties
-        task.overwrite_existing_files = true
-        task.auto_rename_existing_files = true
-        task.configure
-        assert_raises Orocos::StateTransitionFailed do
-            task.start
-        end
-        puts '[INFO] This Error is expected and handled.'
     end
 
     def test_metadata

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -31,7 +31,7 @@ class TC_BasicBehaviour < Minitest::Test
     end
 
     def logfile_path
-        @logfile_io ||= File.open(task.current_file, "w+")
+        @logfile_io ||= File.open(task.current_file)
         @logfile_io.path
     end
 
@@ -69,6 +69,15 @@ class TC_BasicBehaviour < Minitest::Test
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile
+    end
+
+    def test_conflicting_properties_expect_transition_error
+        task.overwrite_existing_files = true
+        task.auto_timestamp_files = true
+        task.configure
+        assert_raises Orocos::StateTransitionFailed do
+            task.start
+        end
     end
 
     def test_no_overwrite_expect_transition_error

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -121,7 +121,7 @@ class TC_BasicBehaviour < Minitest::Test
         assert(!task.has_port?('time'))
         assert(task.createLoggingPort('time', '/base/Time', []))
         generate_and_check_logfile
-        assert(task.file != task.current_file)
+        assert(task.file == task.current_file.split('.')[0])
     end
 
     def test_metadata


### PR DESCRIPTION
Related to https://github.com/rock-core/tools-logger/pull/8

Instead of incrementing the existing logfile a timestamp suffix is added to the existing logfile (if additional auto_rename_existing_file property is true).

In contrast to incrementing, timestamping is more practical in quickly identify recorded log files. Furthermore, especially for a large numbers of recorded files, it is quicker to add a unique timestamp instead of tediously increment through all existing files. The implemented approach assumes that not more than one log file with the same basic _file property is started per second. To be certain, the existence of the timestamped file is checked again and returns false in the startHook if existing.

I adapted the test suite to consider the new task property and handle a possible change of the _file property. To keep the Pocolog stream working without changing the general setup of the test_suite I had to change from Tempfile.open to File.open to prevent Tempfile from adding its own unique tag to the file name. Alternatively one could set @logfile_io.path directly. This is more unstable as it requires that logfile_path() was previously called.

I also adapted the test suite to consider the rock_cxx_type_name to respect the change of metadata introduced in https://github.com/rock-core/tools-logger/commit/1067db83174d5f33a417aaed3800d8ca693b1080