### PR TITLE
Flush and close log files if they are still open at Logger destruction

### DIFF
--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -58,6 +58,10 @@ Logger::Logger(std::string const& name, TaskCore::TaskState initial_state)
 Logger::~Logger()
 {
     clear();
+    if(m_io)
+        m_io->flush();
+    delete m_file;
+    delete m_io;
     delete m_registry;
 }
 


### PR DESCRIPTION
This allows all data that has been received by the logger to be orderly written out and the log file being closed properly, if the task is not moved through STOPPED before being destroyed.