### PR TITLE
feat: allow to control how often the internal buffered I/O is being flushed

### DIFF
--- a/logger.orogen
+++ b/logger.orogen
@@ -50,6 +50,7 @@ task_context "Logger" do
     # The flags are mutually exclusive, therefore the task will fail if both are true.
     property 'overwrite_existing_files', '/bool', false
     property 'auto_timestamp_files'    , '/bool', false
+    property 'flush_period', '/base/Time'
     attribute 'current_file', 'std/string'
 end
 

--- a/tasks/Logger.cpp
+++ b/tasks/Logger.cpp
@@ -52,6 +52,7 @@ Logger::Logger(std::string const& name, TaskCore::TaskState initial_state)
     , m_io(0)
 
 {
+    _flush_period.set(base::Time::fromSeconds(10));
     m_registry = new Typelib::Registry;
 }
 
@@ -71,6 +72,7 @@ bool Logger::startHook()
         return false;
     }
 
+    m_last_flush = base::Time::now();
     return openLogfile(_file);
 }
 
@@ -99,6 +101,12 @@ void Logger::updateHook()
             it->logger->writeSampleHeader(stamp, payload_size);
             it->typelib_marshaller->marshal(it->logger->getStream(), it->marshalling_handle);
         }
+    }
+
+    base::Time now = base::Time::now();
+    if (now - m_last_flush > _flush_period.get()) {
+        m_io->flush();
+        m_last_flush = now;
     }
 }
 

--- a/tasks/Logger.hpp
+++ b/tasks/Logger.hpp
@@ -30,6 +30,7 @@ namespace logger {
         Typelib::Registry* m_registry;
         Logging::Logfile*  m_file;
         std::ofstream*     m_io;
+        base::Time         m_last_flush;
 
         bool startHook();
         void updateHook();


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-syskit/pull/480

This allows to control how much data may be lost in case of crashes, also allowing to reduce the period (thus increasing the I/O load) when debugging such crashes.